### PR TITLE
feat: create article list page with fetch and card display

### DIFF
--- a/client/src/components/ArticleCard/ArticleCard.css
+++ b/client/src/components/ArticleCard/ArticleCard.css
@@ -1,0 +1,30 @@
+.article-card {
+  width: 350px;
+  background-color: var(--primary-color);
+  margin: 20px auto;
+  transition: transform 0.3s ease;
+  border-radius: 20px;
+  cursor: pointer;
+
+  &:hover {
+    transform: scale(1.03);
+  }
+
+  h2 {
+    text-align: center;
+  }
+  img {
+    width: 100%;
+    height: 300px;
+    object-fit: cover;
+  }
+
+  .description {
+    margin: 10px;
+  }
+
+  .price {
+    text-align: center;
+    font-weight: bold;
+  }
+}

--- a/client/src/components/ArticleCard/ArticleCard.tsx
+++ b/client/src/components/ArticleCard/ArticleCard.tsx
@@ -1,0 +1,13 @@
+import "./ArticleCard.css";
+
+function ArticleCard({ article }: { article: Article }) {
+  return (
+    <article className="article-card">
+      <h2>{article.title}</h2>
+      <img src={article.image} alt={article.title} />
+      <p className="price">{article.price} €</p>
+    </article>
+  );
+}
+
+export default ArticleCard;

--- a/client/src/components/Header/Header.tsx
+++ b/client/src/components/Header/Header.tsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router";
 import "./Header.css";
 
 function Header() {
@@ -7,16 +8,16 @@ function Header() {
       <nav>
         <ul>
           <li>
-            <a href="/">Accueil</a>
+            <Link to="/">Accueil</Link>
           </li>
           <li>
-            <a href="/articles">Articles</a>
+            <Link to="/article">Articles</Link>
           </li>
           <li>
-            <a href="/creators">Créateurs</a>
+            <Link to="/creators">Créateurs</Link>
           </li>
           <li>
-            <a href="/contact">Contact</a>
+            <Link to="/contact">Contact</Link>
           </li>
         </ul>
       </nav>

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -3,11 +3,18 @@ import { createRoot } from "react-dom/client";
 import { RouterProvider, createBrowserRouter } from "react-router";
 
 import App from "./App";
+import ArticlePage from "./pages/ArticlePage/ArticlePage";
 
 const router = createBrowserRouter([
   {
     path: "/",
     element: <App />,
+    children: [
+      {
+        path: "/article",
+        element: <ArticlePage />,
+      },
+    ],
   },
 ]);
 

--- a/client/src/pages/ArticlePage/ArticlePage.css
+++ b/client/src/pages/ArticlePage/ArticlePage.css
@@ -1,0 +1,11 @@
+.article-page {
+  h1 {
+    text-align: center;
+  }
+
+  section {
+    display: flex;
+    max-width: 100vw;
+    flex-wrap: wrap;
+  }
+}

--- a/client/src/pages/ArticlePage/ArticlePage.tsx
+++ b/client/src/pages/ArticlePage/ArticlePage.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+import "./ArticlePage.css";
+import ArticleCard from "../../components/ArticleCard/ArticleCard";
+
+function ArticlePage() {
+  const [article, setArticle] = useState<Article[]>([]);
+
+  useEffect(() => {
+    fetch("http://localhost:3310/api/article")
+      .then((res) => res.json())
+      .then((data) => setArticle(data));
+  }, []);
+
+  return (
+    <main className="article-page">
+      <h1>Articles</h1>
+      <section>
+        {article.map((article) => (
+          <ArticleCard key={article.id} article={article} />
+        ))}
+      </section>
+    </main>
+  );
+}
+
+export default ArticlePage;

--- a/client/src/types/Article.ts
+++ b/client/src/types/Article.ts
@@ -1,0 +1,7 @@
+interface Article {
+  id: number;
+  title: string;
+  description: string;
+  price: number;
+  image: string;
+}


### PR DESCRIPTION
This pull request adds an `ArticlePage` to display all articles using reusable UI components and improves navigation with client-side routing.

### Article Display

- `ArticlePage.tsx` & `ArticlePage.css`: New page that fetches and displays articles in a responsive grid.

### Reusable Card Component

- `ArticleCard.tsx` & `ArticleCard.css`: New card to show article details (title, image, price) with clean styling and hover effects.

### Routing

- `main.tsx`: Added route for `/article` to render the new page.

### Navigation

- `Header.tsx`: Updated links to use React Router's `Link` for smoother client-side navigation and fixed a typo in the route path.

### Types

- `Article.ts`: Defined `Article` interface for consistent typing.
